### PR TITLE
Fix typos

### DIFF
--- a/markdown_preview/main_container.py
+++ b/markdown_preview/main_container.py
@@ -390,7 +390,7 @@ class MdMainContainer(Gtk.Box):
 		else:
 			correct_splitter = splitters_array[self._pagination_mode]
 
-		# The document is (as much as possible) splitted in its original
+		# The document is (as much as possible) split in its original
 		# language (md or html). It avoids converting some markdown to html
 		# which wouldn't be rendered anyway.
 		lang_pages = lang_string.split(correct_splitter)

--- a/markdown_preview/prefs/backend_box.ui
+++ b/markdown_preview/prefs/backend_box.ui
@@ -55,7 +55,7 @@
                   <object class="GtkLinkButton">
                     <property name="visible">True</property>
                     <property name="uri">https://python-markdown.github.io/extensions/#officially-supported-extensions</property>
-                    <property name="label" translatable="yes">More informations</property>
+                    <property name="label" translatable="yes">More information</property>
                   </object>
                   <packing>
                     <property name="pack-type">end</property>
@@ -146,7 +146,7 @@
                   <object class="GtkLinkButton">
                     <property name="visible">True</property>
                     <property name="uri">https://pandoc.org/MANUAL.html</property>
-                    <property name="label" translatable="yes">More informations</property>
+                    <property name="label" translatable="yes">More information</property>
                   </object>
                   <packing>
                     <property name="pack-type">end</property>

--- a/markdown_preview/tags_manager.py
+++ b/markdown_preview/tags_manager.py
@@ -21,7 +21,7 @@ class MdTagsManager():
 		self.add_tags_characters(start_tag, end_tag, start, end)
 
 	def remove_line_tags(self, start_tag, end_tag=None):
-		"""Remove `start_tag` from the begining of the line; and `end_tag` from
+		"""Remove `start_tag` from the beginning of the line; and `end_tag` from
 		the end of the line."""
 		if end_tag is None:
 			end_tag = start_tag


### PR DESCRIPTION
Found via `codespell -S ./markdown_preview/locale`