### PR TITLE
utils.py: fix undefined variables introduced in c2e29f0c

### DIFF
--- a/markdown_preview/utils.py
+++ b/markdown_preview/utils.py
@@ -13,7 +13,7 @@ def recognize_format(document):
 		extension = 'md'
 	elif mime and 'html' in mime:
 		extension = 'html'
-	elif file is None:
+	elif name is None:
 		# jadis on avait une API "is_untitled" mais elle a été virée et personne
 		# n'a l'air de savoir pourquoi ni d'en avoir quelque chose à foutre
 		extension = _("Unsaved document")
@@ -30,7 +30,7 @@ def recognize_format(document):
 
 	return extension
 
-def get_display_name():
+def get_display_name(document):
 	file = document.get_file().get_location()
 	if file is None:
 		return None


### PR DESCRIPTION
Since c2e29f0c, `utils.py` had a couple of undefined variables, leading to fatal errors.

 - Renamed `file` to `name` consistently
 - Added `document` parameter to `get_display_name`

This seems to resolve the issues I've been experiencing with 44.2.