### PR TITLE
Replace Deprecated Function to Fix AttributeError

### DIFF
--- a/markdown_preview/prefs/export_assistant.py
+++ b/markdown_preview/prefs/export_assistant.py
@@ -2,7 +2,7 @@
 # GPL v3
 
 import gi, subprocess
-from gi.repository import Gtk, Gio, GLib
+from gi.repository import Gtk, Gio, GLib, Tepl
 
 from .rendering_settings import MdCssSettings, MdRevealjsSettings, MdBackendSettings
 from ..utils import get_backends_dict
@@ -267,7 +267,9 @@ class MdExportAssistant(Gtk.Assistant):
 		file_chooser = Gtk.FileChooserNative.new(_("Export the preview"), \
 		                        self.gedit_window, Gtk.FileChooserAction.SAVE, \
 		                                               _("Export"), _("Cancel"))
-		name = self.gedit_window.get_active_document().get_short_name_for_display()
+		doc = self.gedit_window.get_active_document()
+		tepl_file = Tepl.File.new_for_location(doc.get_location())
+		name = tepl_file.get_short_name()
 		# retirer l'ancienne extension ?
 		name = str(name + ' ' + _("(exported)") + output_extension)
 		file_chooser.set_current_name(name)


### PR DESCRIPTION
### Summary:
This pull request addresses a bug related to the use of a deprecated function in the Gedit Markdown Preview plugin.

### Details:
The plugin was using the `get_short_name_for_display()` function, which has been removed from the Gedit API. This was causing the plugin to crash with an `AttributeError`.

This pull request replaces the deprecated `get_short_name_for_display()` function with the `tepl_file_get_short_name()` function from the Tepl library in the `export_assistant.py` file. This change resolves the error and allows the plugin to function correctly with newer versions of Gedit.

### Related Issue:
This pull request addresses issue [#46](https://github.com/maoschanz/gedit-plugin-markdown_preview/issues/46).

Please review the changes and let me know if anything else is needed. Thank you for your consideration!